### PR TITLE
Bump panda IOC version to 0.6.0

### DIFF
--- a/services/bl38p-ea-panda-01/values.yaml
+++ b/services/bl38p-ea-panda-01/values.yaml
@@ -1,7 +1,7 @@
 shared:
   ioc-instance:
     # Pandablocks IOC image
-    image: ghcr.io/pandablocks/pandablocks-ioc:0.5.0
+    image: ghcr.io/pandablocks/pandablocks-ioc:0.6.0
     # this places the start.sh directly in the epics/ioc folder replacing where
     # the framework usually looks for the global start.sh
     iocConfig: /epics/ioc

--- a/services/bl38p-ea-panda-02/values.yaml
+++ b/services/bl38p-ea-panda-02/values.yaml
@@ -1,6 +1,6 @@
 shared:
   ioc-instance:
-    image: ghcr.io/pandablocks/pandablocks-ioc:0.5.0
+    image: ghcr.io/pandablocks/pandablocks-ioc:0.6.0
     iocConfig: /epics/ioc
 
     securityContext:

--- a/services/bl38p-ea-panda-03/values.yaml
+++ b/services/bl38p-ea-panda-03/values.yaml
@@ -1,6 +1,6 @@
 shared:
   ioc-instance:
-    image: ghcr.io/pandablocks/pandablocks-ioc:0.5.0
+    image: ghcr.io/pandablocks/pandablocks-ioc:0.6.0
     iocConfig: /epics/ioc
 
     securityContext:


### PR DESCRIPTION
Bumps IOC version https://github.com/PandABlocks/PandABlocks-ioc/releases/tag/0.6.0